### PR TITLE
ci: add standard centralized workflows (auto-format, dependabot-automerge, docs-preview-cleanup)

### DIFF
--- a/.github/workflows/DependabotAutoMerge.yml
+++ b/.github/workflows/DependabotAutoMerge.yml
@@ -1,0 +1,9 @@
+name: "Dependabot Auto-merge"
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  automerge:
+    uses: "SciML/.github/.github/workflows/dependabot-automerge.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/RunicSuggestions.yml
+++ b/.github/workflows/RunicSuggestions.yml
@@ -1,0 +1,9 @@
+name: "Runic Suggestions"
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  runic-suggestions:
+    uses: "SciML/.github/.github/workflows/runic-suggestions-on-pr.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Rolls out the standard SciML centralized workflows that were missing from this repo. All are thin caller files pointing at `SciML/.github`.

Added:
- `.github/workflows/RunicSuggestions.yml` — auto-format suggestions on PRs (`runic-suggestions-on-pr.yml@v1`; repo uses Runic for format checking)
- `.github/workflows/DependabotAutoMerge.yml` — auto-merge Dependabot PRs (`dependabot-automerge.yml@v1`)

`DocPreviewCleanup.yml` was intentionally not added: this repo has no `docs/` Documenter site.

Existing workflows were not modified; no source/Project.toml changes.

**Please ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)