### PR TITLE
Add centralized TagBot workflow

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,9 @@
+name: "TagBot"
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+jobs:
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
This repository currently has **no TagBot workflow**, so tagged releases are not being registered/announced. This PR adds one that uses the centralized SciML reusable workflow.

Adds `.github/workflows/TagBot.yml`:

```yaml
name: "TagBot"
on:
  issue_comment:
    types: [created]
  workflow_dispatch:
jobs:
  tagbot:
    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
    secrets: "inherit"
```

Only the new file is added; no other files are changed.

---

**Please ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)