### PR TITLE
Fix Downgrade (QA): remove PATH solve from precompile workload (intermittent libpath50 segfault)

### DIFF
--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -35,9 +35,11 @@ using PrecompileTools: @setup_workload, @compile_workload
         # Also precompile minmax variant
         sol_nr_minmax = solve(prob, NonlinearReformulation(:minmax))
 
-        # Convert LCP to MCP and solve with PATH
-        # This is a common workflow
-        prob_mcp_from_lcp = MCP(prob)
-        sol_mcp_from_lcp = solve(prob_mcp_from_lcp, PATHSolverAlgorithm(); verbose = false)
+        # PATHSolverAlgorithm is intentionally not exercised here. Invoking the
+        # PATH native library (libpath50) inside the precompile worker
+        # segfaults intermittently, which aborts precompilation of the whole
+        # package. Native library calls are not what precompilation caches
+        # anyway, so excluding it loses nothing while making precompilation
+        # deterministic.
     end
 end


### PR DESCRIPTION
## Problem

The `Downgrade (QA)` job on `main` is red. It fails during a from-scratch precompilation of the package with a **segfault in PATHSolver's native library** (`libpath50`):

```
[3632] signal (11.1): Segmentation fault
in expression starting at .../src/precompilation.jl:3
Output_Printf at .../datadeps/libpath50/libpath50.so (unknown line)
ERROR: Failed to precompile ComplementaritySolve ...
```

Because precompilation aborts, the QA testsets (`Aqua`, `ExplicitImports`) error before they run.

The previous Downgrade fix (#64) resolved the earlier `Unsatisfiable requirements` resolution failures in all three groups; Core and Applications are now green. QA was the last remaining red, and its failure is a *different* cause: this precompile segfault.

## Root cause

The `@compile_workload` ends by actually **solving an MCP with `PATHSolverAlgorithm()`**, which calls into the PATH native C library (`libpath50.so`) from inside the precompile worker process. That native call segfaults **intermittently**. Reproduced locally on Julia 1.10.11 with the downgrade-resolved versions (PATHSolver 1.4.0, ForwardDiff 1.0.1, Zygote 0.7.5): roughly **1 in ~20 cold-cache precompiles** crashes with the identical signature (`signal (11): Segmentation fault` in `precompilation.jl`, `Output_Printf at libpath50.so`). Every Downgrade run does a cold precompile, so it hits this regularly.

It is not a Julia-code bug and not a resolution problem — it is the PATH native library being unsafe to invoke inside the precompile worker. (`test/aqua.jl` already disables `persistent_tasks` with the note *"PATHSolver precompile workload triggers persistent task detection"*, and `InteriorPointMethod` is already excluded from the workload for stability.)

## Fix

Remove the PATH solve from the precompile workload. Invoking the PATH solver is the only operation that loads/calls `libpath50` during precompilation, and native C-library calls are not what precompilation caches in the first place — so excluding it loses no meaningful cached coverage while making precompilation deterministic.

## Local verification (Julia 1.10.11, downgrade-resolved versions)

- Before the fix: cold-cache QA precompile segfaults intermittently (reproduced the exact CI signature).
- After the fix: **8/8 cold-cache QA runs pass** (`Aqua`: 3 pass / 1 broken-as-declared; `ExplicitImports`: 2 pass), zero segfaults.
- Package still precompiles cleanly at latest versions on Julia 1.10.

---

Please ignore until reviewed by @ChrisRackauckas

---

**Companion CI fix:** The `CUDA Core` / `CUDA Applications` reds seen on `main` and on this branch are a *separate*, infrastructure-level failure — the two GPU matrix jobs race on the shared self-hosted `~/.gitconfig` inside `codecov-action`'s `safe.directory` setup (tests pass; the post-step exits 255). That is fixed in #67, not here. This PR remains focused on the `Downgrade (QA)` precompile segfault.