### PR TITLE
Fix GPU CI: disable codecov safe.directory write (.gitconfig lock race)

### DIFF
--- a/.github/workflows/GPU.yml
+++ b/.github/workflows/GPU.yml
@@ -43,3 +43,10 @@ jobs:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+          # The two matrix jobs (Core/Applications) share one self-hosted host
+          # and a single ~/.gitconfig. codecov-action's `git config --global
+          # --add safe.directory` setup then races on git's config lock,
+          # failing one job with "could not lock config file ...: File exists"
+          # even though tests pass. The workspace is already owned by the
+          # runner user, so this safe.directory write is unnecessary here.
+          disable_safe_directory: true


### PR DESCRIPTION
## Problem

The `GPU Tests` workflow on `main` is intermittently red. Its two matrix jobs — `CUDA Core` and `CUDA Applications` — run concurrently on the same self-hosted GPU runner host, sharing a single `/home/chrisrackauckas/.gitconfig`.

The `codecov/codecov-action@v7` post-test step runs `git config --global --add safe.directory ...`. When both matrix jobs reach that step at overlapping times, they race on git's config-file lock and one job dies with:

```
error: could not lock config file /home/chrisrackauckas/.gitconfig: File exists
##[error]Process completed with exit code 255.
```

This happens **after** `ComplementaritySolve tests passed` is printed, so the tests themselves are fine — it is purely the codecov action's git-config setup racing. Which of the two jobs loses the race varies run-to-run (it hit `CUDA Applications` on the latest `main` run and `CUDA Core` on a recent PR run), confirming a concurrency race rather than a code/test issue.

`fail_ci_if_error: false` is already set, but it does not help here: the failure is in the action's `safe.directory` *setup* step, which exits 255 before that flag is consulted.

## Fix

Set `disable_safe_directory: true` on the codecov step. This skips the `git config --global --add safe.directory` write, which is the only operation racing on the shared `~/.gitconfig`. The write is unnecessary on these self-hosted runners (the workspace is already owned by the runner user), so disabling it removes the race without masking any failure. The test step (`julia-runtest`) still fully gates the job, and coverage still uploads.

## Notes

- Workflow-only change; no `.jl` files touched (no Runic formatting needed).
- This is a separate concern from the Downgrade (QA) precompile-segfault fix (#66); kept as its own focused PR.
- I confirmed from the CI logs that the failing step is codecov-action's `safe.directory` setup and that the tests pass before it; this is a self-hosted-runner-environment race, so it cannot be reproduced on a non-GPU dev box.

Please ignore until reviewed by @ChrisRackauckas