### PR TITLE
Remove ArrayInterfaceCore can_setindex type piracy (resolves #68)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Avik Pal <avikpal@mit.edu>"]
 version = "1.0.0"
 
 [deps]
-ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
@@ -26,7 +25,6 @@ TruncatedStacktraces = "781d530d-4396-4725-bb49-402e4bee1e77"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-ArrayInterfaceCore = "0.1"
 ChainRulesCore = "1"
 CommonSolve = "0.2.6"
 ConcreteStructs = "0.2"

--- a/src/ComplementaritySolve.jl
+++ b/src/ComplementaritySolve.jl
@@ -45,9 +45,6 @@ const AA3 = AbstractArray{T, 3} where {T}
 
 const DEFAULT_NLSOLVER = SimpleNewtonRaphson()
 
-# NOTE: `can_setindex` for FillArrays (`AbstractFill`/`OneElement`) lives upstream in
-# ArrayInterface (ArrayInterfaceFillArraysExt); see JuliaArrays/ArrayInterface.jl.
-# NOTE: LinearSolve.defaultalg for AbstractSciMLOperator + AbstractGPUArray was upstreamed
 
 abstract type AbstractComplementarityAlgorithm end
 abstract type AbstractComplementaritySystemAlgorithm end

--- a/src/ComplementaritySolve.jl
+++ b/src/ComplementaritySolve.jl
@@ -5,7 +5,6 @@ module ComplementaritySolve
 # Before release we will clean things up
 
 ## Core / QOL Dependencies
-using ArrayInterfaceCore: ArrayInterfaceCore
 using ChainRulesCore: ChainRulesCore, NoTangent, ZeroTangent
 using GPUArraysCore: GPUArraysCore
 using SciMLBase: SciMLBase, FunctionOperator, LinearProblem, NonlinearFunction,
@@ -46,11 +45,8 @@ const AA3 = AbstractArray{T, 3} where {T}
 
 const DEFAULT_NLSOLVER = SimpleNewtonRaphson()
 
-### ----- Type Piracy Starts ----- ###
-ArrayInterfaceCore.can_setindex(::Type{<:AbstractFill}) = false
-ArrayInterfaceCore.can_setindex(::Zygote.OneElement) = false
-
-### ------ Type Piracy Ends ------ ###
+# NOTE: `can_setindex` for FillArrays (`AbstractFill`/`OneElement`) lives upstream in
+# ArrayInterface (ArrayInterfaceFillArraysExt); see JuliaArrays/ArrayInterface.jl.
 # NOTE: LinearSolve.defaultalg for AbstractSciMLOperator + AbstractGPUArray was upstreamed
 
 abstract type AbstractComplementarityAlgorithm end

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -3,7 +3,6 @@ using Aqua, ComplementaritySolve
 Aqua.test_all(
     ComplementaritySolve;
     ambiguities = false,    # Too many ambiguities from downstream
-    piracies = (; broken = true),  # Known type piracy for ArrayInterfaceCore
     persistent_tasks = false,  # PATHSolver precompile workload triggers persistent task detection
     project_extras = false, # Not sure about this one
     deps_compat = false


### PR DESCRIPTION
Resolves #68.

## Summary

Removes the type piracy in `src/ComplementaritySolve.jl`:

```julia
ArrayInterfaceCore.can_setindex(::Type{<:AbstractFill}) = false
ArrayInterfaceCore.can_setindex(::Zygote.OneElement) = false
```

and re-enables the Aqua piracy check (drops `piracies = (; broken = true)`).

## Why this is safe

- **The methods were dead.** They target `ArrayInterfaceCore.can_setindex` (the deprecated 0.1 package), but the current solver stack (LinearSolve/NonlinearSolve) dispatches on `ArrayInterface.can_setindex` — a different function. Nothing in this package calls `can_setindex` itself; `ArrayInterfaceCore` was imported solely to host these two definitions.
- **`AbstractFill`/`OneElement` immutability now lives upstream.** Added in ArrayInterface via a FillArrays extension: JuliaArrays/ArrayInterface.jl#493. It loads automatically here because `FillArrays` is already a dependency and `ArrayInterface` is present transitively (via LinearSolve), so no new direct dependency is needed.
- **`Zygote.OneElement` is no longer produced by Zygote.** In current Zygote (0.7.x) the type is defined but never constructed; `getindex` gradients flow through `ChainRules.OneElement`, which ArrayInterface already covers (`ArrayInterfaceChainRulesExt`).

The unused `ArrayInterfaceCore` dependency (deps + compat) is dropped.

## Testing

`TESTING_GROUP=QA` suite (Aqua + ExplicitImports) run locally and passes 6/6 with the piracy check fully enabled — against the **registry** ArrayInterface (i.e. before #493 releases), confirming no regression in the interim.

> Note: depends conceptually on JuliaArrays/ArrayInterface.jl#493 for the immutability behavior, but is independently correct and mergeable now since the removed piracy was dead.

Draft — please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)